### PR TITLE
Fix incorrect micronaut launch url

### DIFF
--- a/src/main/docs/guide/writingTheApp.adoc
+++ b/src/main/docs/guide/writingTheApp.adoc
@@ -11,7 +11,7 @@ other build tools such as `Maven` or other programming languages such as `Groovy
 
 == Create an App with Micronaut Launch
 
-You can create the app using https://micronaut.com/launch[Micronaut Launch]
+You can create the app using https://micronaut.io/launch[Micronaut Launch]
 
 image::micronautlaunch.png[]
 


### PR DESCRIPTION
The URL seems to be wrong in multiple guides